### PR TITLE
Implement BPMN navigated viewer

### DIFF
--- a/assets/scripts/fullscreen.js
+++ b/assets/scripts/fullscreen.js
@@ -1,5 +1,5 @@
 (() => {
-    document.querySelectorAll('div[data-fullscreen=data-fullscreen]').forEach(container => {
+    document.querySelectorAll('div[data-fullscreen]').forEach(container => {
         const buttons = [container.querySelector(':scope > header > button'), container.querySelector(':scope > footer > button')];
         buttons.forEach(button => {
             button.onclick = (event) => {

--- a/assets/style/page/base.css
+++ b/assets/style/page/base.css
@@ -360,7 +360,6 @@ header nav {
     border-radius: var(--radius-base);
     box-shadow: var(--drop-shadow-level2);
     color: var(--menu-text-color);
-    display: none;
     position: absolute;
     top: 100%;
     margin-top: calc(var(--space-md) * -3/2);
@@ -687,7 +686,54 @@ article > .header-container {
 .bpmn > .bjs-container {
     position: absolute !important;
     top: 0;
+    cursor: move;
 }
+
+[data-fullscreen="false"] .bpmn > .bjs-container {
+    pointer-events: none;
+}
+
+.bpmn-zoom {
+    border-radius: var(--radius-base);
+    box-shadow: var(--drop-shadow-base);
+    display: none;
+    flex-direction: column;
+}
+
+.bpmn-zoom [data-bpmn-zoom] {
+    background-color: var(--color-black-a10);
+    border: none;
+    font-size: var(--heading-2-size);
+    text-align: center;
+    width: var(--space-lg);
+    height: var(--space-lg);
+    line-height: 1;
+    padding: var(--space-sm);
+    transition: background-color var(--duration-base), color var(--duration-base);
+}
+
+.bpmn-zoom [data-bpmn-zoom]:first-child {
+    border-radius: var(--radius-base) var(--radius-base) 0 0;
+}
+
+.bpmn-zoom [data-bpmn-zoom]:last-child {
+    border-radius: 0 0 var(--radius-base) var(--radius-base);
+}
+
+
+.bpmn-zoom [data-bpmn-zoom]:hover,
+.bpmn-zoom [data-bpmn-zoom]:focus {
+    background-color: var(--color-black-a20);
+}
+
+[data-fullscreen="true"] .bpmn-zoom {
+    display: flex;
+}
+
+.bjs-powered-by {
+    display: none;
+}
+
 
 /* Module: Zoom */
 [data-fullscreen] {
@@ -817,13 +863,21 @@ article > .header-container {
     max-width: none;
 }
 
-[data-fullscreen="true"]  iframe.openapi,
-[data-fullscreen="true"]  iframe.asyncapi {
+[data-fullscreen="true"] iframe.openapi,
+[data-fullscreen="true"] iframe.asyncapi {
     min-width: 100%;
     min-height: 100vh;
     margin-left: 0;
     margin-right: 0;
     vertical-align: middle;
+}
+
+[data-fullscreen="true"] .bpmn > .bjs-container {
+    height: 100vh !important;
+}
+
+[data-fullscreen="true"] .bpmn + footer [data-toggle="fullscreen"] {
+    display: none;
 }
 
 /* Tabs */

--- a/bin/app/index.js
+++ b/bin/app/index.js
@@ -186,7 +186,7 @@ module.exports = class App {
             { src: path.resolve(options.nodeModules, 'swagger-ui-dist/swagger-ui-standalone-preset.js'), dst: path.resolve(options.dst, 'assets/swagger-ui-dist') },
             { src: path.resolve(options.nodeModules, 'swagger-ui-dist/swagger-ui-standalone-preset.js.map'), dst: path.resolve(options.dst, 'assets/swagger-ui-dist') },
 
-            { src: path.resolve(options.nodeModules, 'bpmn-js/dist/bpmn-viewer.production.min.js'), dst: path.resolve(options.dst, 'assets/bpmn-js-dist') },
+            { src: path.resolve(options.nodeModules, 'bpmn-js/dist/bpmn-navigated-viewer.production.min.js'), dst: path.resolve(options.dst, 'assets/bpmn-js-dist') },
 
             { src: path.resolve(options.nodeModules, '@asyncapi/html-template/template/css/global.min.css'), dst: path.resolve(options.dst, 'assets/asyncapi/html-template') },
             { src: path.resolve(options.nodeModules, '@asyncapi/html-template/template/css/asyncapi.min.css'), dst: path.resolve(options.dst, 'assets/asyncapi/html-template') },

--- a/bin/components/bpmn-component/template.pug
+++ b/bin/components/bpmn-component/template.pug
@@ -8,6 +8,7 @@ script.
     });
 
     const bpmnContainer = document.getElementById('#{id}');
+    const zoomButtons = bpmnContainer.parentElement.querySelectorAll('footer [data-bpmn-zoom]');
 
     const drawCanvas = () => {
       viewer.importXML(xml)
@@ -15,7 +16,7 @@ script.
           const canvas = viewer.get('canvas');
           let viewbox = canvas.viewbox();
           if (viewbox.inner.width !== 0 && viewbox.inner.height !== 0) {
-            canvas.zoom('fit-viewport');
+            canvas.zoom('fit-viewport', 'auto');
           }
 
           setTimeout(() => {
@@ -24,8 +25,8 @@ script.
             if (viewbox.inner.width !== 0 && viewbox.inner.height !== 0) {
               bpmnContainer.style.paddingTop = (viewbox.inner.height / viewbox.inner.width * 100) + '%';
 
-              setTimeout(() => canvas.zoom('fit-viewport'), 1);
-              setTimeout(() => canvas.zoom('fit-viewport'), 2);
+              setTimeout(() => canvas.zoom('fit-viewport', 'auto'), 1);
+              setTimeout(() => canvas.zoom('fit-viewport', 'auto'), 2);
             }
           }, 1)
 
@@ -35,9 +36,31 @@ script.
         });
     }
 
+    const handleZoom = event => {
+      const canvas = viewer.get('canvas');
+      const z = canvas.zoom();
+
+      switch (event.currentTarget.dataset.bpmnZoom) {
+        case 'in':
+          canvas.zoom(z + .5, 'auto');
+          break;
+
+        case 'out':
+          canvas.zoom(z - .5, 'auto');
+          break;
+
+        default:
+          canvas.zoom('fit-viewport', 'auto');
+      }
+    }
+
     drawCanvas();
 
     window.addEventListener('resize', () => {
       drawCanvas();
-    });     
+    });
+
+    zoomButtons.forEach(button => {
+      button.addEventListener('click', handleZoom);
+    });
   });

--- a/bin/components/fullscreen-component/template.pug
+++ b/bin/components/fullscreen-component/template.pug
@@ -2,11 +2,19 @@ mixin button()
   button(type='button' title='Maximize' data-toggle="fullscreen")
     span(class='label')='Zoom'
 
-div(data-fullscreen)
+div(data-fullscreen="false")
   header
     +button()
   
   | !{html}
   
   footer    
-    +button() 
+    +button()
+    div(class='bpmn-zoom')
+        button(type='button' title='Zoom reset' data-bpmn-zoom="reset")
+            span(class='label')!='&#8634;'
+        button(type='button' title='Zoom in' data-bpmn-zoom="in")
+            span(class='label')!='&plus;'
+        button(type='button' title='Zoom uit' data-bpmn-zoom="out")
+            span(class='label')!='&minus;'
+

--- a/bin/components/page-component/template.pug
+++ b/bin/components/page-component/template.pug
@@ -54,7 +54,7 @@ html
       | !{content}
 
     script(src=relative.root + 'assets/iframe-resizer-dist/iframeResizer.min.js' charset='UTF-8')
-    script(src=relative.root + 'assets/bpmn-js-dist/bpmn-viewer.production.min.js' charset='UTF-8')
+    script(src=relative.root + 'assets/bpmn-js-dist/bpmn-navigated-viewer.production.min.js' charset='UTF-8')
 
     script(src=relative.root + 'assets/prismjs/components/prism-core.min.js' charset='UTF-8')
     script(src=relative.root + 'assets/prismjs/prism-autoloader.min.js' charset='UTF-8')

--- a/bin/components/page-component/template.pug
+++ b/bin/components/page-component/template.pug
@@ -5,10 +5,12 @@ html
     meta(name='viewport' content='width=device-width,initial-scale=1.0')
     meta(name='robots' content='noindex, nofollow')
     title= title 
-    link(rel='stylesheet' type='text/css' href=relative.root + 'assets/style/page/style.css')    
-    link(rel='preconnect' href='https://fonts.googleapis.com')
-    link(rel='preconnect' href='https://fonts.gstatic.com' crossorigin)
-    link(href='https://fonts.googleapis.com/css2?family=Mulish:ital,wght@0,400;0,700;1,400;1,700&display=swap' rel='stylesheet')    
+    link(rel='stylesheet' type='text/css' href=relative.root + 'assets/style/page/style.css')
+    if(data.googleFont)
+      link(rel='preconnect' href='https://fonts.googleapis.com')
+      link(rel='preconnect' href='https://fonts.gstatic.com' crossorigin)
+      link(href=data.googleFont rel='stylesheet')
+      
     link(href=relative.root + 'assets/prismjs/prism-coy.min.css' rel='stylesheet')
     link(href=relative.root + 'assets/prismjs/prism-line-numbers.min.css' rel='stylesheet')
 

--- a/bin/file-parsers/markdown-file-parser/index.js
+++ b/bin/file-parsers/markdown-file-parser/index.js
@@ -52,7 +52,8 @@ module.exports = class MarkdownFileParser {
             url: url,
             content: element.innerHTML,
             title: response.title,        
-            git: this.gitInfo
+            git: this.gitInfo,
+            data: this.options.page || {}
         });
     }
 }

--- a/tests/options.yml
+++ b/tests/options.yml
@@ -15,6 +15,8 @@ hosting:
   responseOverrides:
     401: /signin
     403: /signedin
+page:
+  googleFont: 'https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,300;0,400;0,600;1,300;1,400;1,600&display=swap'
 email:  
   googleFont: 'https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,300;0,400;0,600;1,300;1,400;1,600&display=swap'
   from:


### PR DESCRIPTION
#181

Om de zoom functie te implementeren van BPMN viewer moest de BPMN Navigated Viewer worden gebruikt. Zonder kun je nl. wel zoomen maar niet in het model slepen. Bijkomstigheid is dat nu ook muis scroll functie worden ondersteund. Zo kun je nu ‘navigeren’ door het model, zoals verticaal verplaatsen (scroll), horizontaal (shift + scroll) verplaatsen en zoomen (ctrl + scroll).