### PR TITLE
WIP: Fix: Responive embed resizing

### DIFF
--- a/assets/style/page/element/_base.css
+++ b/assets/style/page/element/_base.css
@@ -72,7 +72,8 @@ a:focus {
 }
 
 figure img,
-figure svg {
+figure svg,
+figure embed {
     max-width: 100%;
     height: auto;
     vertical-align: middle;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synion/md-docs",
-  "version": "1.0.65",
+  "version": "1.0.66",
   "description": "Business driven living documentation static site generator.",
   "keywords": [
     "cli",


### PR DESCRIPTION
Het <embed> element stond niet goed ingesteld om responsive te resizen. Alle content in de embed werd daardoor op 100% getoond.